### PR TITLE
Bookings with `in_cart` status do not conflict

### DIFF
--- a/src/BookingConflictConditionFactory.php
+++ b/src/BookingConflictConditionFactory.php
@@ -109,6 +109,13 @@ class BookingConflictConditionFactory implements FactoryInterface
 
         return $b->and(
             $overlap,
+            // Booking status is not `in_cart`
+            $b->not(
+                $b->eq(
+                    $b->ef('booking', 'status'),
+                    $b->lit(S::STATUS_IN_CART)
+                )
+            ),
             // Bookings' service IDs are the same
             $b->eq(
                 $b->ef('booking', 'service_id'),


### PR DESCRIPTION
Resolves #4 

----

**Note**: these changes are made on top of the changes made in PR #6, branch `fix/3_remove-booking-status-conflict-exception`. The target merge branch for this PR has been set accordingly.